### PR TITLE
Fix warning

### DIFF
--- a/src/weatherdotgov.rs
+++ b/src/weatherdotgov.rs
@@ -127,7 +127,6 @@
  * 
  */
 
-use reqwest::Error;
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Deserialize)]


### PR DESCRIPTION
Fixes #6

Remove the unused import `use reqwest::Error;` from `src/weatherdotgov.rs` to fix the warning emitted during the test process.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ephbaum/wxdotgov/issues/6?shareId=8cbb99a2-d86b-4803-9fd7-1dfec6e07042).