### PR TITLE
ci(lints): move warning and clippy deny rules to package [lints] table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,9 @@ serde = { version = "1.0.196", features = ["derive"] }
 tokio = { version = "1.35.1", features = ["full"] }
 mockito = "1.2.0"
 serde_json = "1.0"
+
+[lints.rust]
+warnings = "deny"
+
+[lints.clippy]
+all = "deny"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-/** 
+/* 
  * wxdotgov
  * 
  * a program that takes a US postal code or a city name and, optionally, a state code and outputs the location's weather
@@ -74,13 +74,6 @@ enum ForecastType {
     Hourly,
 }
 
-#[cfg(test)]
-mod tests {
-    mod integration_tests;
-    mod api_tests;
-    mod app_tests;
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     // Parse command-line arguments.
@@ -89,7 +82,7 @@ async fn main() -> Result<()> {
     // Build the location input.
     let location_input = if let Some(zip) = args.zip {
         LocationInput::PostalCode(zip)
-    } else if let Some(city) = args.city.clone() {
+    } else if let Some(city) = args.city {
         if let Some(state) = args.state {
             LocationInput::CityWithState(city, state)
         } else {
@@ -116,7 +109,7 @@ async fn main() -> Result<()> {
         ForecastType::Detailed => &points_resp.properties.forecast,
     };
 
-    println!("Fetching forecast from: {}", forecast_url);
+    println!("Fetching forecast from: {forecast_url}");
 
     // Step 3: Fetch and display the forecast.
     if args.forecast_type == ForecastType::Detailed {
@@ -129,7 +122,7 @@ async fn main() -> Result<()> {
         println!();
 
         // Print each detailed forecast period.
-        for period in forecast_resp.properties.periods.iter() {
+        for period in &forecast_resp.properties.periods {
             if args.pretty {
                 // Bold and blue for the period name.
                 println!("{}", period.name.bold().blue());
@@ -156,7 +149,7 @@ async fn main() -> Result<()> {
         println!();
 
         // Print each hourly forecast period.
-        for period in hourly_forecast_resp.properties.periods.iter() {
+        for period in &hourly_forecast_resp.properties.periods {
             if args.pretty {
                 // Bold and blue for the start time.
                 println!("{}", period.start_time.bold().blue());
@@ -189,4 +182,11 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    mod integration_tests;
+    mod api_tests;
+    mod app_tests;
 }

--- a/src/nomatim.rs
+++ b/src/nomatim.rs
@@ -1,4 +1,4 @@
-/**
+/*
  * Nomatim API
  * 
  * This module contains the Nomatim API
@@ -35,13 +35,13 @@ pub async fn get_lat_lon(input: LocationInput, base_url: Option<&str>) -> Result
     let client = reqwest::Client::new();
 
     let query = match input {
-        LocationInput::PostalCode(code) => format!("{}, USA", code),
-        LocationInput::PostalCodePlusFour(code, _) => format!("{}, USA", code),
-        LocationInput::City(city) => format!("{}, USA", city),
-        LocationInput::CityWithState(city, state) => format!("{}, {}, USA", city, state),
+        LocationInput::PostalCode(code) => format!("{code}, USA"),
+        LocationInput::PostalCodePlusFour(code, _) => format!("{code}, USA"),
+        LocationInput::City(city) => format!("{city}, USA"),
+        LocationInput::CityWithState(city, state) => format!("{city}, {state}, USA"),
     };
 
-    let url = format!("{}/search", base_url);
+    let url = format!("{base_url}/search");
 
     let response = client
         .get(&url)

--- a/src/weatherdotgov.rs
+++ b/src/weatherdotgov.rs
@@ -1,4 +1,4 @@
-/**
+/*
  * WeatherDotGov API
  * 
  * This module contains the WeatherDotGov API
@@ -180,7 +180,7 @@ pub struct HourlyPeriod {
 }
 
 pub async fn get_weather_point(latitude: &str, longitude: &str) -> Result<PointsResponse> {
-    let points_url = format!("https://api.weather.gov/points/{},{}", latitude, longitude);
+    let points_url = format!("https://api.weather.gov/points/{latitude},{longitude}");
     let client = reqwest::Client::new();
     
     let response = client
@@ -193,7 +193,7 @@ pub async fn get_weather_point(latitude: &str, longitude: &str) -> Result<Points
 
     if !response.status().is_success() {
         let error_text = response.text().await.context("Error reading error response")?;
-        bail!("Weather.gov returned an error for points data: {}", error_text);
+        bail!("Weather.gov returned an error for points data: {error_text}");
     }
 
     let points_resp: PointsResponse = response
@@ -214,7 +214,7 @@ pub async fn get_detailed_forecast(forecast_url: &str) -> Result<ForecastRespons
 
     if !response.status().is_success() {
         let error_text = response.text().await.context("Error reading forecast error response")?;
-        bail!("Weather.gov returned an error for forecast: {}", error_text);
+        bail!("Weather.gov returned an error for forecast: {error_text}");
     }
 
     let forecast_resp: ForecastResponse = response
@@ -238,7 +238,7 @@ pub async fn get_hourly_forecast(forecast_url: &str) -> Result<HourlyForecastRes
             .text()
             .await
             .context("Error reading hourly forecast error response")?;
-        bail!("Weather.gov returned an error for hourly forecast: {}", error_text);
+        bail!("Weather.gov returned an error for hourly forecast: {error_text}");
     }
 
     let hourly_forecast_resp: HourlyForecastResponse = response


### PR DESCRIPTION
## Problem
As described in #32, setting `RUSTFLAGS: -Dwarnings` or enforcing crate warnings globally leaks to third-party dependencies compiled by Cargo, turning CI red when upstream dependencies or toolchain updates emit warnings in external crates.

## Solution
- Added package-scoped `[lints.rust] warnings = "deny"` and `[lints.clippy] all = "deny"` to `Cargo.toml` (stable since Rust 1.74), ensuring strict lint enforcement is isolated strictly to `wxdotgov`.
- Updated doc comment delimiters (`/**` to `/*`) to prevent unused doc comment diagnostics on following use statements.
- Relocated the test module below `main` to satisfy `clippy::items_after_test_module`.
- Removed a redundant clone on `args.city` in `src/main.rs`.
- Inlined format arguments across modules to satisfy `clippy::uninlined_format_args`.
- Verified `cargo clippy --all-targets` and `cargo test` pass cleanly with zero warnings/errors.

Fixes #32